### PR TITLE
feat: 4.4節LoRAノートブックにHF推論フォールバックを追加

### DIFF
--- a/notebooks/chapter04/section04_lora.ipynb
+++ b/notebooks/chapter04/section04_lora.ipynb
@@ -282,51 +282,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 生成テスト\n",
-    "\n",
-    "学習済みモデルを使って、いくつかのプロンプトからテキスト生成を行います。"
-   ]
+   "source": "## 学習済みモデルによる生成テスト\n\n学習をスキップした場合、または学習済みモデルで推論のみ行いたい場合は、以下のセルを実行してください。ローカルにアダプターがあればそれを使用し、なければ Hugging Face からダウンロードします。"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# テスト用プロンプト\n",
-    "test_prompts = [\n",
-    "    \"吾輩は猫である。名前はまだ無い。\",\n",
-    "    \"明治時代の\",\n",
-    "    \"東京の街には\",\n",
-    "    \"先生は言った。「\",\n",
-    "]\n",
-    "\n",
-    "model.eval()\n",
-    "device = next(model.parameters()).device\n",
-    "\n",
-    "for i, prompt in enumerate(test_prompts, 1):\n",
-    "    inputs = tokenizer(prompt, return_tensors=\"pt\", add_special_tokens=True)\n",
-    "    inputs = {k: v.to(device) for k, v in inputs.items()}\n",
-    "\n",
-    "    with torch.no_grad():\n",
-    "        output = model.generate(\n",
-    "            **inputs,\n",
-    "            max_new_tokens=80,\n",
-    "            do_sample=True,\n",
-    "            temperature=0.8,\n",
-    "            top_p=0.9,\n",
-    "            repetition_penalty=1.2,\n",
-    "            pad_token_id=tokenizer.pad_token_id,\n",
-    "            eos_token_id=tokenizer.eos_token_id,\n",
-    "        )\n",
-    "\n",
-    "    generated_text = tokenizer.decode(output[0], skip_special_tokens=True)\n",
-    "    generated_part = generated_text[len(prompt):]\n",
-    "    print(f\"[{i}] プロンプト: {prompt}\")\n",
-    "    print(f\"    生成結果: {generated_part[:200]}\")\n",
-    "    print()"
-   ]
+   "source": "import os\nfrom peft import PeftModel\n\nMODEL_NAME = \"rinna/japanese-gpt2-medium\"\nlocal_adapter_path = \"./models/rinna-gpt2-aozora-lora/adapter\"\nhf_repo = \"elith/llm-book-models\"\nhf_subfolder = \"chapter04/lora\"\n\n# ベースモデルとトークナイザの読み込み\ntokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, use_fast=False)\nif tokenizer.pad_token is None:\n    tokenizer.pad_token = tokenizer.eos_token\nbase_model = GPT2LMHeadModel.from_pretrained(MODEL_NAME)\n\n# LoRAアダプターの読み込み（ローカル優先、なければHFからダウンロード）\nif os.path.exists(os.path.join(local_adapter_path, \"adapter_config.json\")):\n    print(f\"ローカルのアダプターを使用: {local_adapter_path}\")\n    model = PeftModel.from_pretrained(base_model, local_adapter_path)\nelse:\n    print(f\"Hugging Faceからアダプターをダウンロード: {hf_repo}/{hf_subfolder}\")\n    model = PeftModel.from_pretrained(base_model, hf_repo, subfolder=hf_subfolder)\n\ndevice = \"cuda\" if torch.cuda.is_available() else \"cpu\"\nmodel = model.to(device)\nmodel.eval()\nprint(f\"デバイス: {device}\")\n\n# テスト用プロンプト\ntest_prompts = [\n    \"吾輩は猫である。名前はまだ無い。\",\n    \"明治時代の\",\n    \"東京の街には\",\n    \"先生は言った。「\",\n]\n\nfor i, prompt in enumerate(test_prompts, 1):\n    inputs = tokenizer(prompt, return_tensors=\"pt\", add_special_tokens=True)\n    inputs = {k: v.to(device) for k, v in inputs.items()}\n\n    with torch.no_grad():\n        output = model.generate(\n            **inputs,\n            max_new_tokens=80,\n            do_sample=True,\n            temperature=0.8,\n            top_p=0.9,\n            repetition_penalty=1.2,\n            pad_token_id=tokenizer.pad_token_id,\n            eos_token_id=tokenizer.eos_token_id,\n        )\n\n    generated_text = tokenizer.decode(output[0], skip_special_tokens=True)\n    generated_part = generated_text[len(prompt):]\n    print(f\"[{i}] プロンプト: {prompt}\")\n    print(f\"    生成結果: {generated_part[:200]}\")\n    print()"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- 4.4節LoRAノートブックの生成テストセクションに、Hugging Faceからのアダプターダウンロード機能を追加
- ローカルにアダプターがない場合、`elith/llm-book-models` から自動ダウンロード（5章と同じパターン）