### PR TITLE
feat: apply PEP 735

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=7.4.0",
     "black>=23.0.0",
     "isort>=5.12.0",


### PR DESCRIPTION
Suppress warning blow

```shell
$ uv sync
warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
```

https://peps.python.org/pep-0735/